### PR TITLE
bugfix: fix use of retry-after when it exists in the header

### DIFF
--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -36,7 +36,7 @@ T = TypeVar('T')
 
 
 class PipeRunExtractor:
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
 
     def __init__(self,
                  token: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ warn_unused_ignores = true
 name = "piperun-extractor"
 description = "PipeRun Extractor Tool/Lib"
 readme = "README.md"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
     { name = "Tonin Bolzan", email = "tonin@crmpiperun.com" }
 ]


### PR DESCRIPTION
tests:
`2025-06-05 11:05:52,461 - WARNING - Rate limit exceeded. Retrying in 29 seconds.`