### PR TITLE
feat: Adicionar campos created_at e updated_at

### DIFF
--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -230,7 +230,7 @@ class PipeRunExtractor:
         return self._fetch(piperun.schema.custom_fields.CustomFieldResponse, 'customFields', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def custom_forms(self, after: datetime) -> Iterator[piperun.schema.custom_forms.CustomForm]:
-        return self._fetch(piperun.schema.custom_forms.CustomForm, 'customForms', {'show': 200, 'with': 'fields'})  # full fetch
+        return self._fetch(piperun.schema.custom_forms.CustomForm, 'customForms', {'show': 200, 'with': 'fields', 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})  # full fetch
 
     def notes(self, after: datetime) -> Iterator[piperun.schema.notes.Note]:
         return self._fetch(piperun.schema.notes.Note, 'notes', {'show': 100, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
@@ -263,7 +263,7 @@ class PipeRunExtractor:
         return self._fetch(piperun.schema.emails.EmailTemplate, 'email/templates', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def origins(self, after: datetime) -> Iterator[piperun.schema.origins.Origin]:
-        return self._fetch(piperun.schema.origins.Origin, 'origins', {'show': 200})  # full fetch
+        return self._fetch(piperun.schema.origins.Origin, 'origins', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})  # full fetch
 
     def origins_groups(self, after: datetime) -> Iterator[piperun.schema.origins.OriginGroup]:
         return self._fetch(piperun.schema.origins.OriginGroup, 'originGroups', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -230,7 +230,7 @@ class PipeRunExtractor:
         return self._fetch(piperun.schema.custom_fields.CustomFieldResponse, 'customFields', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def custom_forms(self, after: datetime) -> Iterator[piperun.schema.custom_forms.CustomForm]:
-        return self._fetch(piperun.schema.custom_forms.CustomForm, 'customForms', {'show': 200, 'with': 'fields', 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})  # full fetch
+        return self._fetch(piperun.schema.custom_forms.CustomForm, 'customForms', {'show': 200, 'with': 'fields', 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def notes(self, after: datetime) -> Iterator[piperun.schema.notes.Note]:
         return self._fetch(piperun.schema.notes.Note, 'notes', {'show': 100, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
@@ -263,7 +263,7 @@ class PipeRunExtractor:
         return self._fetch(piperun.schema.emails.EmailTemplate, 'email/templates', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def origins(self, after: datetime) -> Iterator[piperun.schema.origins.Origin]:
-        return self._fetch(piperun.schema.origins.Origin, 'origins', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})  # full fetch
+        return self._fetch(piperun.schema.origins.Origin, 'origins', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def origins_groups(self, after: datetime) -> Iterator[piperun.schema.origins.OriginGroup]:
         return self._fetch(piperun.schema.origins.OriginGroup, 'originGroups', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -36,7 +36,7 @@ T = TypeVar('T')
 
 
 class PipeRunExtractor:
-    VERSION = '1.0.4'
+    VERSION = '1.0.5'
 
     def __init__(self,
                  token: str,

--- a/piperun/schema/activities.py
+++ b/piperun/schema/activities.py
@@ -59,6 +59,8 @@ class ActivityType:
     description_html: str | None
     description_text: str | None
     is_active: bool | None
+    updated_at: datetime | None
+    created_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -68,3 +70,5 @@ class ActivityType:
         self.description_html = utils.parse_str(k, 'description')
         self.description_text = utils.parse_html2text(k, 'description')
         self.is_active = utils.parse_bool(k, 'active')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')

--- a/piperun/schema/companies.py
+++ b/piperun/schema/companies.py
@@ -113,6 +113,8 @@ class Segment:
     description_html: str | None
     description_text: str | None
     sector: int | None
+    updated_at: datetime | None
+    created_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -120,3 +122,5 @@ class Segment:
         self.description_html = utils.parse_str(k, 'description')
         self.description_text = utils.parse_html2text(k, 'description')
         self.sector = utils.parse_int(k, 'sector')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')

--- a/piperun/schema/custom_fields.py
+++ b/piperun/schema/custom_fields.py
@@ -21,6 +21,8 @@ class CustomFieldResponse:
     equation_decimal_places: int | None
     equation_allow_negative: str | None
     equation_currency_id: str | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -40,6 +42,8 @@ class CustomFieldResponse:
         self.equation_decimal_places = utils.parse_int(k, 'decimal_places')
         self.equation_allow_negative = utils.parse_str(k, 'allow_negative')
         self.equation_currency_id = utils.parse_str(k, 'currency_id')
+        self.created_at = utils.parse_date(k, 'created_at')
+        self.updated_at = utils.parse_date(k, 'updated_at')
 
 @dataclass
 class EntityHasCustomField:

--- a/piperun/schema/custom_forms.py
+++ b/piperun/schema/custom_forms.py
@@ -13,6 +13,8 @@ class CustomForm:
     is_active: bool | None
     page_title: str | None
     fields: list
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -22,6 +24,8 @@ class CustomForm:
         self.is_active = utils.parse_bool(k, 'status')
         self.page_title = utils.parse_str(k, 'page_title')
         self.fields = utils.parse_list(k, 'fields', CustomFormField)
+        self.created_at = utils.parse_date(k, 'created_at')
+        self.updated_at = utils.parse_date(k, 'updated_at')
 
 
 @dataclass

--- a/piperun/schema/deals.py
+++ b/piperun/schema/deals.py
@@ -122,8 +122,12 @@ class LostReason:
     id: int | None
     name: str | None
     is_active: bool | None
+    updated_at: datetime | None
+    created_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
         self.name = utils.parse_str(k, 'name')
         self.is_active = utils.parse_bool(k, 'status')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -25,6 +25,8 @@ class Item:
     code: str | None
     fix_commission_value: float | None
     is_product_belong_deal: bool | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -46,6 +48,8 @@ class Item:
         self.code = utils.parse_str(k, 'code')
         self.fix_commission_value = utils.parse_float(k, 'fix_commission_value')
         self.is_product_belong_deal = utils.parse_bool(k, 'is_product_belong_deal')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')
 
 
 @dataclass
@@ -106,6 +110,8 @@ class Category:
     description: str | None
     reference: str | None
     is_deleted: bool | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -114,3 +120,5 @@ class Category:
         self.description = utils.parse_str(k, 'description')
         self.reference = utils.parse_str(k, 'reference')
         self.is_deleted = utils.parse_bool(k, 'deleted')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')

--- a/piperun/schema/origins.py
+++ b/piperun/schema/origins.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from piperun import utils
 
@@ -11,6 +12,8 @@ class Origin:
     description_html: str | None
     description_text: str | None
     is_active: bool | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -19,6 +22,8 @@ class Origin:
         self.description_html = utils.parse_str(k, 'description')
         self.description_text = utils.parse_html2text(k, 'description')
         self.is_active = utils.parse_bool(k, 'active')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')
 
 
 @dataclass
@@ -28,6 +33,8 @@ class OriginGroup:
     description_html: str | None
     description_text: str | None
     is_active: bool | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -35,3 +42,5 @@ class OriginGroup:
         self.description_html = utils.parse_str(k, 'description')
         self.description_text = utils.parse_html2text(k, 'description')
         self.is_active = utils.parse_bool(k, 'active')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')

--- a/piperun/schema/pipeline.py
+++ b/piperun/schema/pipeline.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from piperun import utils
 
@@ -17,6 +18,8 @@ class Pipeline:
     is_main: bool | None
     limit_time: int | None
     visibility: int | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -31,6 +34,8 @@ class Pipeline:
         self.is_main = utils.parse_bool(k, 'is_main')
         self.limit_time = utils.parse_int(k, 'limit_time')
         self.visibility = utils.parse_int(k, 'visibility')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')
 
 
 @dataclass
@@ -47,6 +52,8 @@ class Stage:
     block_emails: int | None
     days_limit: int | None
     update_limit: int | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -61,3 +68,6 @@ class Stage:
         self.block_emails = utils.parse_int(k, 'block_emails')
         self.days_limit = utils.parse_int(k, 'days_limit')
         self.update_limit = utils.parse_int(k, 'update_limit')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')
+

--- a/piperun/schema/regions.py
+++ b/piperun/schema/regions.py
@@ -16,6 +16,7 @@ class Region:
     balance: int | None
     created_at: datetime | None
     cities: list
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -27,3 +28,4 @@ class Region:
         self.balance = utils.parse_int(k, 'balance')
         self.created_at = utils.parse_date(k, 'created_at')
         self.cities = utils.parse_list(k, 'cities', City)
+        self.updated_at = utils.parse_date(k, 'updated_at')

--- a/piperun/schema/tags.py
+++ b/piperun/schema/tags.py
@@ -13,6 +13,7 @@ class Tag:
     created_at: datetime | None
     belongs: int | None
     is_active: bool | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -22,3 +23,4 @@ class Tag:
         self.created_at = utils.parse_date(k, 'created_at')
         self.belongs = utils.parse_int(k, 'belongs')
         self.is_active = utils.parse_bool(k, 'active')
+        self.updated_at = utils.parse_date(k, 'updated_at')

--- a/piperun/schema/users.py
+++ b/piperun/schema/users.py
@@ -21,6 +21,7 @@ class User:
     telephone: str | None
     created_at: datetime | None
     created_by: int | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -38,6 +39,7 @@ class User:
         self.telephone = utils.parse_str(k, 'telephone')
         self.created_at = utils.parse_date(k, 'created_at')
         self.created_by = utils.parse_int(k, 'created_by')
+        self.updated_at = utils.parse_date(k, 'updated_at')
 
 
 @dataclass
@@ -48,6 +50,8 @@ class Team:
     leader_id: int | None
     deal_user_id: int | None
     deal_quantity: int | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
@@ -56,6 +60,8 @@ class Team:
         self.leader_id = utils.parse_int(k, 'leader_id')  # User.id
         self.deal_user_id = utils.parse_int(k, 'deal_user_id')  # User.id
         self.deal_quantity = utils.parse_int(k, 'deal_quantity')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+        self.created_at = utils.parse_date(k, 'created_at')
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ warn_unused_ignores = true
 name = "piperun-extractor"
 description = "PipeRun Extractor Tool/Lib"
 readme = "README.md"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
     { name = "Tonin Bolzan", email = "tonin@crmpiperun.com" }
 ]


### PR DESCRIPTION
Este PR adiciona os campos created_at e updated_at às seguintes classes/models para melhor rastreamento de criação e atualização de registros:

- ActivityType  
- Segment  
- CustomFieldResponse  
- CustomForm  
- LostReason  
- Item  
- Category  
- Origin  
- OriginGroup  
- Pipeline  
- Team  

Além disso, o campo updated_at foi adicionado às seguintes classes/models:

- Region  
- Tag  
- User  

Essas alterações visam melhorar o versionamento e a rastreabilidade dos dados nas respectivas entidades.