### PR TITLE
refactor(headers): alteração dos headers para uso padronizado do throttle

### DIFF
--- a/piperun/cli.py
+++ b/piperun/cli.py
@@ -89,9 +89,6 @@ def execute_one(piperun: PipeRunExtractor, method: str, after: datetime, extensi
               help='Output Extension')
 @click.option('-o', '--output', show_envvar=True, required=True,
               help='Output Location')
-@click.option('--throttle', show_envvar=True, required=False,
-              callback=validate_token,
-              help='Throttle Token')
 @click.option('--log', show_envvar=True, required=False, default='warning', show_default=True,
               type=click.Choice(['critical', 'error', 'warning', 'info', 'debug']),
               help='Log level')
@@ -101,12 +98,11 @@ def execute_one(piperun: PipeRunExtractor, method: str, after: datetime, extensi
 @click.option('--url', show_envvar=True, required=False, default='https://api.pipe.run/v1', show_default=True,
               type=click.STRING,
               help='PipeRun API')
-def main(token, throttle, log, origin, url, after, ext, output, method: str):
+def main(token, log, origin, url, after, ext, output, method: str):
     assert_output(method, ext, output)
 
     piperun = PipeRunExtractor(
         token=token,
-        token_throttle=throttle,
         log_level=log,
         origin=origin,
         base_url=url,

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -37,7 +37,7 @@ T = TypeVar('T')
 
 
 class PipeRunExtractor:
-    VERSION = '1.2.2'
+    VERSION = '2.0.0'
 
     def __init__(self,
                  token: str,

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -37,11 +37,10 @@ T = TypeVar('T')
 
 
 class PipeRunExtractor:
-    VERSION = '1.2.1'
+    VERSION = '1.2.2'
 
     def __init__(self,
                  token: str,
-                 token_throttle: str = '',
                  origin: str = '',
                  log_level: str = 'WARNING',
                  base_url: str = 'https://api.pipe.run/v1',
@@ -51,12 +50,8 @@ class PipeRunExtractor:
         if not re.fullmatch(r"[a-fA-F0-9]{32}", token):
             raise Exception('Invalid token')
 
-        if token_throttle and not re.fullmatch(r"[a-fA-F0-9]{32}", token_throttle):
-            raise Exception('Invalid skip throttle token')
-
         self.headers = {
             'Token': token,
-            'X-Token-Skip-Throttle': token_throttle,
             'X-Application-Id': 'crm-extractor',
             'User-Agent': 'piperun-extractor/' + self.VERSION,
             'Origin': utils.parse_origin(origin),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ warn_unused_ignores = true
 name = "piperun-extractor"
 description = "PipeRun Extractor Tool/Lib"
 readme = "README.md"
-version = "1.2.1"
+version = "1.2.2"
 authors = [
     { name = "Tonin Bolzan", email = "tonin@crmpiperun.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ warn_unused_ignores = true
 name = "piperun-extractor"
 description = "PipeRun Extractor Tool/Lib"
 readme = "README.md"
-version = "1.2.2"
+version = "2.0.0"
 authors = [
     { name = "Tonin Bolzan", email = "tonin@crmpiperun.com" }
 ]


### PR DESCRIPTION
- Remove parâmetro `--throttle` do CLI
- Remove `token_throttle` do construtor do PipeRunExtractor
- Remove header `X-Token-Skip-Throttle` das requisições
- Remove validação do token de throttle