### PR TITLE
Feat: adicionando listagem de DealHasItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ custom_fields                   Iterator[schema.custom_fields.CustomFieldRespons
 deals_has_custom_fields         Iterator[schema.custom_fields.EntityHasCustomField]
 companies_has_custom_fields     Iterator[schema.custom_fields.EntityHasCustomField]
 persons_has_custom_fields       Iterator[schema.custom_fields.EntityHasCustomField]
-deals_has_products              Iterator[schema.items.DealHasProduct]
+deals_has_items                 Iterator[schema.items.DealHasItem]
 custom_forms                    Iterator[schema.custom_forms.CustomForm]
 notes                           Iterator[schema.notes.Note]
 items                           Iterator[schema.items.Item]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ custom_fields                   Iterator[schema.custom_fields.CustomFieldRespons
 deals_has_custom_fields         Iterator[schema.custom_fields.EntityHasCustomField]
 companies_has_custom_fields     Iterator[schema.custom_fields.EntityHasCustomField]
 persons_has_custom_fields       Iterator[schema.custom_fields.EntityHasCustomField]
+deals_has_products              Iterator[schema.items.DealHasProduct]
 custom_forms                    Iterator[schema.custom_forms.CustomForm]
 notes                           Iterator[schema.notes.Note]
 items                           Iterator[schema.items.Item]

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -108,11 +108,11 @@ class PipeRunExtractor:
                 self.logger.debug(f'Requesting {endpoint} with params {params}')
                 response = requests.get(endpoint, params=params, headers=self.headers, timeout=60, verify=True)
                 code = response.status_code
-                
+
                 if 'Retry-After' in response.headers:
                     has_retry_header = True
                     retry_after = max(retry_after, int(response.headers.get('Retry-After', retry_after)))
-    
+
                 if 200 <= code < 300:
                     return response.json()
             except RequestException as e:
@@ -136,7 +136,7 @@ class PipeRunExtractor:
                 self.logger.error(f'Request failed with status code {code}. Retrying in {retry_after} seconds.')
                 # if error is unknown, timeout, 5xx or 4xx: reduce the number of items to retrieve
                 params['show'] = max(1, min(200, math.ceil(int(params.get('show', 1)) / 2)))  # Cut show in half every error
-    
+
             if has_retry_header:
                 time.sleep(retry_after)  # Use Retry-After value directly
             else:
@@ -279,8 +279,8 @@ class PipeRunExtractor:
     def persons_has_custom_fields(self,  after: datetime) -> Iterator[piperun.schema.custom_fields.EntityHasCustomField]:
         return self._fetch(piperun.schema.custom_fields.EntityHasCustomField, 'persons/custom-fields', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
-    def deals_has_products(self, after: datetime) -> Iterator[piperun.schema.items.DealHasProduct]:
-        return self._fetch(piperun.schema.items.DealHasProduct, 'deals/products', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
+    def deals_has_items(self, after: datetime) -> Iterator[piperun.schema.items.DealHasItem]:
+        return self._fetch(piperun.schema.items.DealHasItem, 'deals/items', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def goals_active(self, after: datetime) -> Iterator[piperun.schema.goals.Goal]:
         situation_active = 1

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -37,7 +37,7 @@ T = TypeVar('T')
 
 
 class PipeRunExtractor:
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
 
     def __init__(self,
                  token: str,
@@ -278,6 +278,9 @@ class PipeRunExtractor:
 
     def persons_has_custom_fields(self,  after: datetime) -> Iterator[piperun.schema.custom_fields.EntityHasCustomField]:
         return self._fetch(piperun.schema.custom_fields.EntityHasCustomField, 'persons/custom-fields', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
+
+    def deals_has_products(self, after: datetime) -> Iterator[piperun.schema.items.DealHasProduct]:
+        return self._fetch(piperun.schema.items.DealHasProduct, 'deals/products', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def goals_active(self, after: datetime) -> Iterator[piperun.schema.goals.Goal]:
         situation_active = 1

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -106,7 +106,7 @@ class PipeRunExtractor:
             code = 0
             try:
                 self.logger.debug(f'Requesting {endpoint} with params {params}')
-                response = requests.get(endpoint, params=params, headers=self.headers, timeout=60, verify=True)
+                response = requests.get(endpoint, params=params, headers=self.headers, timeout=60, verify=False)
                 code = response.status_code
 
                 if 'Retry-After' in response.headers:

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -108,7 +108,6 @@ class DealHasProduct:
     deal_id: int | None
     product_id: int | None
     custom_field_id: int | None
-    brand_id: int | None
     status: int | None
     quantity: float | None
     value: float | None
@@ -135,7 +134,6 @@ class DealHasProduct:
         self.deal_id = utils.parse_int(k, 'deal_id')  # Deal.id
         self.product_id = utils.parse_int(k, 'product_id')  # Item.id
         self.custom_field_id = utils.parse_int(k, 'custom_field_id')  # CustomField.id
-        self.brand_id = utils.parse_int(k, 'brand_id')  # Company.id
         self.status = utils.parse_int(k, 'status')
         self.quantity = utils.parse_float(k, 'quantity')
         self.value = utils.parse_float(k, 'value')

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -132,7 +132,7 @@ class DealHasItem:
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
         self.deal_id = utils.parse_int(k, 'deal_id')  # Deal.id
-        self.item_id = utils.parse_int(k, 'product_id')  # Item.id
+        self.item_id = utils.parse_int(k, 'item_id')  # Item.id
         self.custom_field_id = utils.parse_int(k, 'custom_field_id')  # CustomField.id
         self.status = utils.parse_int(k, 'status')
         self.quantity = utils.parse_float(k, 'quantity')

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -103,10 +103,10 @@ class CharacteristicOption:
 
 
 @dataclass
-class DealHasProduct:
+class DealHasItem:
     id: int | None
     deal_id: int | None
-    product_id: int | None
+    item_id: int | None
     custom_field_id: int | None
     status: int | None
     quantity: float | None
@@ -132,7 +132,7 @@ class DealHasProduct:
     def __init__(self, **k):
         self.id = utils.parse_int(k, 'id')
         self.deal_id = utils.parse_int(k, 'deal_id')  # Deal.id
-        self.product_id = utils.parse_int(k, 'product_id')  # Item.id
+        self.item_id = utils.parse_int(k, 'product_id')  # Item.id
         self.custom_field_id = utils.parse_int(k, 'custom_field_id')  # CustomField.id
         self.status = utils.parse_int(k, 'status')
         self.quantity = utils.parse_float(k, 'quantity')

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -103,6 +103,62 @@ class CharacteristicOption:
 
 
 @dataclass
+class DealHasProduct:
+    id: int | None
+    deal_id: int | None
+    product_id: int | None
+    custom_field_id: int | None
+    brand_id: int | None
+    status: int | None
+    quantity: float | None
+    value: float | None
+    ipi_tax: float | None
+    ipi_value: float | None
+    discount_type: int | None
+    discount_value: float | None
+    discount_value_absolute: float | None
+    discount_value_percentage: float | None
+    sub_total_value: float | None
+    total_value: float | None
+    cost: float | None
+    markup_type: int | None
+    markup_value: float | None
+    markup_value_absolute: float | None
+    markup_value_percentage: float | None
+    duration: int | None
+    formula_text: str | None
+    created_at: datetime | None
+    updated_at: datetime | None
+
+    def __init__(self, **k):
+        self.id = utils.parse_int(k, 'id')
+        self.deal_id = utils.parse_int(k, 'deal_id')  # Deal.id
+        self.product_id = utils.parse_int(k, 'product_id')  # Item.id
+        self.custom_field_id = utils.parse_int(k, 'custom_field_id')  # CustomField.id
+        self.brand_id = utils.parse_int(k, 'brand_id')  # Company.id
+        self.status = utils.parse_int(k, 'status')
+        self.quantity = utils.parse_float(k, 'quantity')
+        self.value = utils.parse_float(k, 'value')
+        self.ipi_tax = utils.parse_float(k, 'ipi_tax')
+        self.ipi_value = utils.parse_float(k, 'ipi_value')
+        self.discount_type = utils.parse_int(k, 'discount_type')
+        self.discount_value = utils.parse_float(k, 'discount_value')
+        self.discount_value_absolute = utils.parse_float(k, 'discount_value_absolute')
+        self.discount_value_percentage = utils.parse_float(k, 'discount_value_percentage')
+        self.sub_total_value = utils.parse_float(k, 'sub_total_value')
+        self.total_value = utils.parse_float(k, 'total_value')
+        self.cost = utils.parse_float(k, 'cost')
+        self.markup_type = utils.parse_int(k, 'markup_type')
+        self.markup_value = utils.parse_float(k, 'markup_value')
+        self.markup_value_absolute = utils.parse_float(k, 'markup_value_absolute')
+        self.markup_value_percentage = utils.parse_float(k, 'markup_value_percentage')
+        self.duration = utils.parse_int(k, 'duration')
+        self.formula_text = utils.parse_str(k, 'formula_text')
+        self.created_at = utils.parse_date(k, 'created_at')
+        self.updated_at = utils.parse_date(k, 'updated_at')
+
+
+@dataclass
 class Category:
     id: int | None
     category_id: int | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ warn_unused_ignores = true
 name = "piperun-extractor"
 description = "PipeRun Extractor Tool/Lib"
 readme = "README.md"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     { name = "Tonin Bolzan", email = "tonin@crmpiperun.com" }
 ]


### PR DESCRIPTION
## Descrição
Adiciona a extração de produtos associados a deals (`deal_has_item`), expondo a relação entre negócios e itens do catálogo com os respectivos valores, descontos, markup e impostos.

## O que mudou                                                                
  - **Novo dataset `deals_has_items`**: método `deals_has_items(after)` em `PipeRunExtractor`, consumindo o endpoint `deals/items` com paginação (`show=200`) e filtro incremental por `updated_at_start`.                     
  - **Novo schema `DealHasItem`** (`piperun/schema/items.py`): mapeia os campos da relação identificadores (`deal_id`, `item_id`, `custom_field_id`), `status`, `quantity`, valores (`value`, `sub_total_value`, `total_value`, `cost`), descontos (`discount_*`), markup (`markup_*`), IPI (`ipi_tax`, `ipi_value`), `duration`, `formula_text` e timestamps.            
  - **README**: `deals_has_items` documentado na lista de datasets disponíveis.                                                                  
  - **Versão**: bump `2.0.0` → `2.1.0` (`extractor.py` e `pyproject.toml`).