### PR TITLE
Múltiplas marcas por item (`items_has_brands`) e remoção de `brand_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ items                           Iterator[schema.items.Item]
 items_characteristics           Iterator[schema.items.Characteristic]
 items_categories                Iterator[schema.items.Category]
 items_measurement_units         Iterator[schema.items.MeasurementUnit]
+items_has_brands                Iterator[piperun.schema.items.ItemHasBrand]:
 datalists                       Iterator[schema.data_lists.DataList]
 tags                            Iterator[schema.tags.Tag]
 cnaes                           Iterator[schema.cnaes.Cnae]

--- a/piperun/extractor.py
+++ b/piperun/extractor.py
@@ -37,7 +37,7 @@ T = TypeVar('T')
 
 
 class PipeRunExtractor:
-    VERSION = '2.1.0'
+    VERSION = '3.0.0'
 
     def __init__(self,
                  token: str,
@@ -245,6 +245,9 @@ class PipeRunExtractor:
 
     def items_measurement_units(self, after: datetime) -> Iterator[piperun.schema.items.MeasurementUnit]:
         return self._fetch(piperun.schema.items.MeasurementUnit, 'measurementUnit', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
+
+    def items_has_brands(self, after: datetime) -> Iterator[piperun.schema.items.ItemHasBrand]:
+        return self._fetch(piperun.schema.items.ItemHasBrand, 'items/brands', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})
 
     def datalists(self, after: datetime) -> Iterator[piperun.schema.data_lists.DataList]:
         return self._fetch(piperun.schema.data_lists.DataList, 'datalists', {'show': 200, 'updated_at_start': after.strftime('%Y-%m-%d %H:%M:%S')})

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -19,7 +19,6 @@ class Item:
     is_active: bool | None
     photo: str | None
     commission: float | None
-    brand_id: int | None
     ipi_tax: float | None
     measurement_unit_id: int | None
     code: str | None
@@ -42,7 +41,6 @@ class Item:
         self.is_active = not utils.parse_bool(k, 'status')
         self.photo = utils.parse_url(k, 'photo')
         self.commission = utils.parse_float(k, 'commission')
-        self.brand_id = utils.parse_int(k, 'brand_id')  # Company.id
         self.ipi_tax = utils.parse_float(k, 'ipi_tax')
         self.measurement_unit_id = utils.parse_int(k, 'measurement_unit_id')  # MeasurementUnit.id
         self.code = utils.parse_str(k, 'code')
@@ -176,3 +174,17 @@ class Category:
         self.is_deleted = utils.parse_bool(k, 'deleted')
         self.updated_at = utils.parse_date(k, 'updated_at')
         self.created_at = utils.parse_date(k, 'created_at')
+
+
+@dataclass
+class ItemHasBrand:
+    item_id: int | None
+    brand_id: int | None
+    created_at: datetime | None
+    updated_at: datetime | None
+
+    def __init__(self, **k):
+        self.item_id = utils.parse_int(k, 'item_id')  # Item.id
+        self.brand_id = utils.parse_int(k, 'brand_id')  # Company.id
+        self.created_at = utils.parse_date(k, 'created_at')
+        self.updated_at = utils.parse_date(k, 'updated_at')

--- a/piperun/schema/items.py
+++ b/piperun/schema/items.py
@@ -178,12 +178,14 @@ class Category:
 
 @dataclass
 class ItemHasBrand:
+    id: int | None
     item_id: int | None
     brand_id: int | None
     created_at: datetime | None
     updated_at: datetime | None
 
     def __init__(self, **k):
+        self.id = utils.parse_int(k, 'id')
         self.item_id = utils.parse_int(k, 'item_id')  # Item.id
         self.brand_id = utils.parse_int(k, 'brand_id')  # Company.id
         self.created_at = utils.parse_date(k, 'created_at')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ warn_unused_ignores = true
 name = "piperun-extractor"
 description = "PipeRun Extractor Tool/Lib"
 readme = "README.md"
-version = "2.1.0"
+version = "3.0.0"
 authors = [
     { name = "Tonin Bolzan", email = "tonin@crmpiperun.com" }
 ]


### PR DESCRIPTION
## Contexto

O relacionamento entre item e marca deixou de ser 1:1 e passou a ser N:N. Antes cada item carregava um único `brand_id`; agora um item pode estar associado a múltiplas marcas. Esta PR alinha o extractor a esse novo modelo.

## O que mudou

- **Novo método `items_has_brands(after)`** — expõe as relações item↔marca via endpoint `items/brands`, retornando `Iterator[ItemHasBrand]`.
- **Nova dataclass `ItemHasBrand`** (`piperun/schema/items.py`) com os campos `item_id`, `brand_id`, `created_at` e `updated_at`.
- **Remoção de `brand_id` de `Item`** — campo depreciado, tanto do dataclass quanto do parsing em `__init__`. A associação passa a ser consumida exclusivamente por `items_has_brands`.
- **Bump de versão `2.1.0` → `3.0.0`**.

## Breaking change ⚠️

A remoção de `Item.brand_id` quebra qualquer consumidor que lê a marca diretamente do item. Por isso o bump é **major (3.0.0)**.

**Migração:** substituir a leitura de `item.brand_id` pela junção via `items_has_brands`, agrupando por `item_id`. Um item sem marca simplesmente não aparecerá na coleção; um item com N marcas aparecerá em N registros.